### PR TITLE
Setup build-logic module to extract common config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,8 +6,8 @@ android {
     namespace = "com.github.nisrulz.devicetypektxproject"
 
     defaultConfig {
-        versionCode = APP_VERSION_CODE
-        versionName = APP_VERSION_NAME
+        versionCode = ApplicationInfo.APPLICATION_VERSION_CODE
+        versionName = ApplicationInfo.APPLICATION_VERSION_NAME
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,51 +1,13 @@
 plugins {
-    alias(libs.plugins.androidApplication)
-    alias(libs.plugins.jetbrainsKotlinAndroid)
+    id("app-convention")
 }
 
 android {
     namespace = "com.github.nisrulz.devicetypektxproject"
-    compileSdk = 34
 
     defaultConfig {
-        applicationId = "com.github.nisrulz.devicetypektxproject"
-        minSdk = 21
-        targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        vectorDrawables {
-            useSupportLibrary = true
-        }
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.10"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
+        versionCode = APP_VERSION_CODE
+        versionName = APP_VERSION_NAME
     }
 }
 
@@ -71,5 +33,6 @@ dependencies {
     // implementation(project(":devicetypektx"))
 
     // Maven
-    implementation("com.github.nisrulz:devicetypektx:1.0.0")
+    val deviceTypeKtxVer = "1.0.1"
+    implementation("com.github.nisrulz:devicetypektx:$deviceTypeKtxVer")
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    `kotlin-dsl`
+    `kotlin-dsl-precompiled-script-plugins`
+}
+
+repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation(libs.gradle)
+    implementation(libs.kotlin.gradle.plugin)
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,9 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/AndroidConfig.kt
+++ b/build-logic/src/main/kotlin/AndroidConfig.kt
@@ -1,14 +1,28 @@
 import org.gradle.api.JavaVersion
 
-const val COMPILE_SDK_VERSION = 34
-const val MIN_SDK_VERSION = 21
-const val TARGET_SDK_VERSION = 34
-val JAVA_COMPAT_VERSION = JavaVersion.VERSION_1_8
+internal object BuildSdkInfo {
+    const val COMPILE_SDK_VERSION = 34
+    const val MIN_SDK_VERSION = 21
+    const val TARGET_SDK_VERSION = 34
+    val JAVA_COMPAT_VERSION = JavaVersion.VERSION_1_8
+}
 
-// Application Version
-const val APP_VERSION_CODE = 1
-const val APP_VERSION_NAME = "1.0"
+object ApplicationInfo {
+    const val APPLICATION_VERSION_NAME = "1.0"
+    const val APPLICATION_VERSION_CODE = 1
+}
 
-// Library Version
-const val LIBRARY_VERSION_NAME = "1.0.1"
-const val LIBRARY_VERSION_CODE = 1
+object LibraryInfo {
+    const val POM_VERSION = "1.0.2"
+    const val POM_ARTIFACT_ID = "devicetypektx"
+    const val POM_NAME = "Device Type KTX"
+    const val POM_DESCRIPTION =
+        "Android library to provide Kotlin extensions for working with specific device types."
+    const val POM_INCEPTION_YEAR = "2024"
+
+    private const val GITHUB_REPO_NAME = "device-type-ktx"
+    const val POM_URL = "https://github.com/nisrulz/$GITHUB_REPO_NAME/"
+    const val POM_SCM_URL = "https://github.com/nisrulz/$GITHUB_REPO_NAME/"
+    const val POM_SCM_CONNECTION = "scm:git:git://github.com/nisrulz/$GITHUB_REPO_NAME.git"
+    const val POM_SCM_DEV_CONNECTION = "scm:git:ssh://git@github.com/nisrulz/$GITHUB_REPO_NAME.git"
+}

--- a/build-logic/src/main/kotlin/AndroidConfig.kt
+++ b/build-logic/src/main/kotlin/AndroidConfig.kt
@@ -1,0 +1,14 @@
+import org.gradle.api.JavaVersion
+
+const val COMPILE_SDK_VERSION = 34
+const val MIN_SDK_VERSION = 21
+const val TARGET_SDK_VERSION = 34
+val JAVA_COMPAT_VERSION = JavaVersion.VERSION_1_8
+
+// Application Version
+const val APP_VERSION_CODE = 1
+const val APP_VERSION_NAME = "1.0"
+
+// Library Version
+const val LIBRARY_VERSION_NAME = "1.0.1"
+const val LIBRARY_VERSION_CODE = 1

--- a/build-logic/src/main/kotlin/VersionCatalogExtensions.kt
+++ b/build-logic/src/main/kotlin/VersionCatalogExtensions.kt
@@ -1,0 +1,46 @@
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ExternalModuleDependencyBundle
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.plugin.use.PluginDependency
+
+private val Project.catalog
+    get() = extensions.getByType<VersionCatalogsExtension>()
+
+internal val Project.libs: VersionCatalog
+    get() = catalog.named("libs")
+
+private fun VersionCatalog.findVersionOrThrow(name: String) =
+    findVersion(name)
+        .orElseThrow { NoSuchElementException("Version $name not found in version catalog") }
+        .requiredVersion
+
+internal fun Project.applyPlugin(
+    alias: String,
+    block: (Provider<PluginDependency>) -> Unit,
+) {
+    libs.findPlugin(alias).ifPresent { plugin ->
+        block(plugin)
+    }
+}
+
+internal fun Project.applyBundle(
+    alias: String,
+    block: (Provider<ExternalModuleDependencyBundle>) -> Unit,
+) {
+    libs.findBundle(alias).ifPresent { bundle ->
+        block(bundle)
+    }
+}
+
+internal fun Project.applyLibrary(
+    alias: String,
+    block: (Provider<MinimalExternalModuleDependency>) -> Unit,
+) {
+    libs.findLibrary(alias).ifPresent { lib ->
+        block(lib)
+    }
+}

--- a/build-logic/src/main/kotlin/app-convention.gradle.kts
+++ b/build-logic/src/main/kotlin/app-convention.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 
 android {
 
-    compileSdk = COMPILE_SDK_VERSION
+    compileSdk = BuildSdkInfo.COMPILE_SDK_VERSION
 
     defaultConfig {
-        minSdk = MIN_SDK_VERSION
-        targetSdk = TARGET_SDK_VERSION
+        minSdk = BuildSdkInfo.MIN_SDK_VERSION
+        targetSdk = BuildSdkInfo.TARGET_SDK_VERSION
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -41,10 +41,10 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JAVA_COMPAT_VERSION
-        targetCompatibility = JAVA_COMPAT_VERSION
+        sourceCompatibility = BuildSdkInfo.JAVA_COMPAT_VERSION
+        targetCompatibility = BuildSdkInfo.JAVA_COMPAT_VERSION
     }
     kotlinOptions {
-        jvmTarget = JAVA_COMPAT_VERSION.toString()
+        jvmTarget = BuildSdkInfo.JAVA_COMPAT_VERSION.toString()
     }
 }

--- a/build-logic/src/main/kotlin/app-convention.gradle.kts
+++ b/build-logic/src/main/kotlin/app-convention.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+
+    compileSdk = COMPILE_SDK_VERSION
+
+    defaultConfig {
+        minSdk = MIN_SDK_VERSION
+        targetSdk = TARGET_SDK_VERSION
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables {
+            useSupportLibrary = true
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
+
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.10"
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JAVA_COMPAT_VERSION
+        targetCompatibility = JAVA_COMPAT_VERSION
+    }
+    kotlinOptions {
+        jvmTarget = JAVA_COMPAT_VERSION.toString()
+    }
+}

--- a/build-logic/src/main/kotlin/library-convention.gradle.kts
+++ b/build-logic/src/main/kotlin/library-convention.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    compileSdk = COMPILE_SDK_VERSION
+
+    defaultConfig {
+        minSdk = MIN_SDK_VERSION
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JAVA_COMPAT_VERSION
+        targetCompatibility = JAVA_COMPAT_VERSION
+    }
+    kotlinOptions {
+        jvmTarget = JAVA_COMPAT_VERSION.toString()
+    }
+}

--- a/build-logic/src/main/kotlin/library-convention.gradle.kts
+++ b/build-logic/src/main/kotlin/library-convention.gradle.kts
@@ -4,10 +4,10 @@ plugins {
 }
 
 android {
-    compileSdk = COMPILE_SDK_VERSION
+    compileSdk = BuildSdkInfo.COMPILE_SDK_VERSION
 
     defaultConfig {
-        minSdk = MIN_SDK_VERSION
+        minSdk = BuildSdkInfo.MIN_SDK_VERSION
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
@@ -24,10 +24,10 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JAVA_COMPAT_VERSION
-        targetCompatibility = JAVA_COMPAT_VERSION
+        sourceCompatibility = BuildSdkInfo.JAVA_COMPAT_VERSION
+        targetCompatibility = BuildSdkInfo.JAVA_COMPAT_VERSION
     }
     kotlinOptions {
-        jvmTarget = JAVA_COMPAT_VERSION.toString()
+        jvmTarget = BuildSdkInfo.JAVA_COMPAT_VERSION.toString()
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,26 +12,30 @@ plugins {
 }
 
 //region Publishing Tasks
-tasks.register("publishToMavenLocal") {
+tasks.register("releaseToMavenLocal") {
     doLast {
         exec {
-            commandLine = listOf(
-                "./gradlew",
-                ":devicetypektx:assembleRelease",
-                ":devicetypektx:publishToMavenLocal", "--no-configuration-cache"
-            )
+            commandLine =
+                listOf(
+                    "./gradlew",
+                    ":devicetypektx:assembleRelease",
+                    ":devicetypektx:publishToMavenLocal",
+                    "--no-configuration-cache",
+                )
         }
     }
 }
 
-tasks.register("publishToMavenCentral") {
+tasks.register("releaseToMavenCentral") {
     doLast {
         exec {
-            commandLine = listOf(
-                "./gradlew",
-                ":devicetypektx:assembleRelease",
-                ":devicetypektx:publishAllPublicationsToMavenCentral", "--no-configuration-cache"
-            )
+            commandLine =
+                listOf(
+                    "./gradlew",
+                    ":devicetypektx:assembleRelease",
+                    ":devicetypektx:publishToMavenCentral",
+                    "--no-configuration-cache",
+                )
         }
     }
 }
@@ -41,9 +45,13 @@ tasks.register("publishToMavenCentral") {
 tasks.register("assembleDocs") {
     doLast {
         exec {
-            commandLine = listOf(
-                "./gradlew", ":devicetypektx:dokkaHtml", "--quiet", "--no-configuration-cache"
-            )
+            commandLine =
+                listOf(
+                    "./gradlew",
+                    ":devicetypektx:dokkaHtml",
+                    "--quiet",
+                    "--no-configuration-cache",
+                )
         }
     }
 }

--- a/dev-docs.md
+++ b/dev-docs.md
@@ -2,20 +2,23 @@
 
 ## Publishing
 
-- To publish library to maven local:
+- To release library to MavenLocal(~/.m2/):
 
   ```sh
-  ./gradlew publishToMavenLocal
+  ./gradlew releaseToMavenLocal
   ```
 
-- To publish library to maven central:
-  
+- To release library
+  to [MavenCentral](https://search.maven.org/artifact/com.github.nisrulz/devicetypektx):
+
   ```sh
-  ./gradlew publishToMavenCentral
+  ./gradlew releaseToMavenCentral
   ```
-  
+
 - To generate documentation:
 
   ```sh
   ./gradlew assembleDocs
   ```
+  > Docs are automatically published from the Github repo, via GH Pages building from `docs` dir
+  from `master` branch.

--- a/devicetypektx/build.gradle.kts
+++ b/devicetypektx/build.gradle.kts
@@ -2,8 +2,7 @@ import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.jetbrainsKotlinAndroid)
+    id("library-convention")
 
     // Maven Publishing Plugin
     alias(libs.plugins.mavenPublishing)
@@ -14,31 +13,6 @@ plugins {
 
 android {
     namespace = "com.github.nisrulz.devicetypektx"
-    compileSdk = 34
-
-    defaultConfig {
-        minSdk = 21
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }
 
 dependencies {

--- a/devicetypektx/build.gradle.kts
+++ b/devicetypektx/build.gradle.kts
@@ -23,10 +23,27 @@ dependencies {
     dokkaHtmlPlugin(libs.dokka.versioning)
 }
 
+// Maven
+mavenPublishing {
+    coordinates(artifactId = LibraryInfo.POM_ARTIFACT_ID, version = LibraryInfo.POM_VERSION)
+
+    pom {
+        name.set(LibraryInfo.POM_NAME)
+        description.set(LibraryInfo.POM_DESCRIPTION)
+        inceptionYear.set(LibraryInfo.POM_INCEPTION_YEAR)
+        url.set(LibraryInfo.POM_URL)
+        scm {
+            url.set(LibraryInfo.POM_SCM_URL)
+            connection.set(LibraryInfo.POM_SCM_CONNECTION)
+            developerConnection.set(LibraryInfo.POM_SCM_DEV_CONNECTION)
+        }
+    }
+}
+
 //region Dokka Configurations
 
 // Library Version
-val currentVersion = "1.0.1"
+val currentVersion = LibraryInfo.POM_VERSION
 
 /*
  How to Use

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,21 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-####################### Publishing #######################
-# Increase timeout when pushing to Sonatype (otherwise we get timeouts)
-systemProp.org.gradle.internal.http.socketTimeout=120000
-# Publish to Maven Central
-SONATYPE_HOST=DEFAULT
-# Build Type
-ANDROID_VARIANT_TO_PUBLISH=release
-### POM Details
-POM_ARTIFACT_ID=devicetypektx
-VERSION_NAME=1.0.1
-POM_NAME=Device Type KTX
-POM_DESCRIPTION=Android library to provide Kotlin extensions for working with specific device types.
-POM_INCEPTION_YEAR=2024
-POM_URL=https://github.com/nisrulz/device-type-ktx
-POM_SCM_URL=https://github.com/nisrulz/device-type-ktx
-POM_SCM_CONNECTION=scm:git:git://github.com/nisrulz/device-type-ktx.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/nisrulz/device-type-ktx.git
-###########################################################

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.3.0"
 kotlin = "1.9.22"
+
 coreKtx = "1.12.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"
@@ -15,6 +16,13 @@ mavenPublish = "0.28.0"
 dokka = "1.9.20"
 
 [libraries]
+
+# build-logic
+gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+#----- end
+
+
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
@@ -33,8 +41,8 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 # Dokka Plugins
-dokka-android = { group = "org.jetbrains.dokka", name="android-documentation-plugin", version.ref = "dokka" }
-dokka-versioning = { group = "org.jetbrains.dokka", name="versioning-plugin", version.ref = "dokka" }
+dokka-android = { group = "org.jetbrains.dokka", name = "android-documentation-plugin", version.ref = "dokka" }
+dokka-versioning = { group = "org.jetbrains.dokka", name = "versioning-plugin", version.ref = "dokka" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,6 @@
 pluginManagement {
+    includeBuild("build-logic")
+
     repositories {
         google {
             content {

--- a/usage-docs.md
+++ b/usage-docs.md
@@ -6,12 +6,13 @@ DeviceTypeKTX is published to MavenCentral, so you can add it to your project in
 
 ```kotlin
 dependencies {
-    implementation("com.github.nisrulz:devicetypektx:${latest_version}")
+    val deviceTypeKtxVer = "1.0.1"
+    implementation("com.github.nisrulz:devicetypektx:$deviceTypeKtxVer")
     //...other dependencies
 }
 ```
 
-where `latest_version` is the latest version available on MavenCentral : [![Maven Central](https://img.shields.io/maven-central/v/com.github.nisrulz/devicetypektx)](https://central.sonatype.com/search?q=com.github.nisrulz.devicetypektx)
+where `deviceTypeKtxVer` is the latest version available on MavenCentral : [![Maven Central](https://img.shields.io/maven-central/v/com.github.nisrulz/devicetypektx)](https://central.sonatype.com/search?q=com.github.nisrulz.devicetypektx)
 
 [Read API docs here](https://nisrulz.com/device-type-ktx/)
 


### PR DESCRIPTION
- Updated release task names
- Replace gradle.properties values with one defined via build.gradle.kts dsl
- Extract configurables into AndroidConfig.kt file inside build-logic module.
- Extract common configs into convention plugins i.e app and library.
- Updated to next version v1.0.2